### PR TITLE
chore: update package type to "module"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "events-ts",
+  "name": "ee-typed",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "events-ts",
+      "name": "ee-typed",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "typed-emitter": "^2.1.0"
       },
       "devDependencies": {
-        "typescript": "^5.4.5"
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@types/node": {
@@ -48,9 +48,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.4.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
-      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,8 @@
   "description": "EventEmitter with type information",
   "type": "module",
   "main": "dist/src/index.js",
-  "devDependencies": {
-    "typescript": "^5.4.5"
-  },
   "scripts": {
+    "build": "rm -rf dist && tsc",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -30,5 +28,8 @@
   "dependencies": {
     "@types/node": "^20.14.2",
     "typed-emitter": "^2.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ee-typed",
   "version": "0.1.0",
   "description": "EventEmitter with type information",
+  "type": "module",
   "main": "dist/src/index.js",
   "devDependencies": {
     "typescript": "^5.4.5"


### PR DESCRIPTION
This PR resolves compatibility issues with Node.js by setting the package type to module in package.json. This ensures the package works in both modern browsers and Node.js environments.

In addition, this PR also adds a script to build the library.

Related: https://github.com/voltrevo/summon-ts/pull/1